### PR TITLE
Ensure update and close buttons always appear on edit configuration card

### DIFF
--- a/src/Components/Modals/EditModal.razor
+++ b/src/Components/Modals/EditModal.razor
@@ -579,7 +579,6 @@
 </div>
 
 
-
 @code {
     [CascadingParameter] BlazoredModalInstance ModalInstance { get; set; } = new();
     [Parameter] public ThemeInfo theme { get; set; } = new();

--- a/src/Components/Modals/EditModal.razor
+++ b/src/Components/Modals/EditModal.razor
@@ -572,11 +572,10 @@
         </div>
     </div>
 </div>
-</div>
-
 <div class="modern-modal-footer">
     <button title="Save" @onclick="Save" class="modern-btn-success">Update</button>
     <button title="Cancel" @onclick="Cancel" class="modern-btn-secondary">Close</button>
+</div>
 </div>
 
 

--- a/src/Components/Modals/EditModal.razor
+++ b/src/Components/Modals/EditModal.razor
@@ -576,7 +576,6 @@
     <button title="Save" @onclick="Save" class="modern-btn-success">Update</button>
     <button title="Cancel" @onclick="Cancel" class="modern-btn-secondary">Close</button>
 </div>
-</div>
 
 
 @code {

--- a/src/Components/Modals/EditModal.razor
+++ b/src/Components/Modals/EditModal.razor
@@ -62,6 +62,7 @@
                         </div>
                     }
                 }
+                </div>
                 <div class="modern-card" style="margin-bottom: 1rem;">
                     <div class="modern-card-header">
                         Configuration
@@ -571,11 +572,12 @@
             </div>
         </div>
     </div>
+    <div class="modern-modal-footer">
+        <button title="Save" @onclick="Save" class="modern-btn-success">Update</button>
+        <button title="Cancel" @onclick="Cancel" class="modern-btn-secondary">Close</button>
+    </div>
 </div>
-<div class="modern-modal-footer">
-    <button title="Save" @onclick="Save" class="modern-btn-success">Update</button>
-    <button title="Cancel" @onclick="Cancel" class="modern-btn-secondary">Close</button>
-</div>
+
 
 
 @code {


### PR DESCRIPTION
In my browser, the Update and Close buttons on the footer of the edit configuration card were not appearing unless I reduced my browser zoom levels.

The fix, I believe, is to move the footer into the modern-modal-content, rather than have it outside the content.